### PR TITLE
belt and suspenders changes to make sure we find compilers

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -17,5 +17,7 @@ make_spack --spack_release $spackver --minimal -u $dest
 
 source $dest/setup-env.sh
 
+spack compiler find --scope=site
+
 cd $dest/spack-infrastructure/$ver/NULL && bin/declare_simple spack-infrastructure $ver
 

--- a/bin/make_spack
+++ b/bin/make_spack
@@ -64,6 +64,7 @@ bootstrap_patchelf() {
 }
 
 find_compilers() {
+   source $SPACK_ROOT/share/spack/setup-env.sh
    spack compiler find --scope=site
 }
 


### PR DESCRIPTION
This sources the setup script before doing the spack compiler find in make_spack, and also does an other spack compiler find in bootstrap.