### PR TITLE
bug/no devel no external

### DIFF
--- a/bin/make_packages_yaml
+++ b/bin/make_packages_yaml
@@ -314,8 +314,8 @@ do
     if [ "x$v" = x ]
     then
         # not found...
-        echo "Notice: no version found for package $p"
-        echo "Need to install rpm: $lp"
+        echo "Notice: no version found for Spack package $lp"
+        echo "Need to install rpm: $p"
         continue
     fi
 

--- a/bin/make_packages_yaml
+++ b/bin/make_packages_yaml
@@ -320,8 +320,12 @@ do
     fi
 
     # check for installed devel rpm, otherwise warn
-    rpm -q "$dv"  > /dev/null || 
-        echo "Need to install rpm: $dv"
+    if ! { rpm -q "$dv" || echo "$p" | egrep "$no_devel"; } > /dev/null
+    then
+      echo "Notice: no devel headers/libraries found for package $p"
+      echo "Need to install rpm: $dv"
+      continue
+    fi
 
     echo "  $lp:"               >&3
     if echo $lp | egrep "$force_x86_64" > /dev/null


### PR DESCRIPTION
- Add ftgl to force_x86_64
- Correct Spack name for pkgconfig RPM from pkgconf to pkg-config
- SL7 *does* have pkg-config (pkgconfig.freedesktop.org)
- No devel -> no external (cannot build against)
- Fix misleading message
