### PR TITLE
Repository parameters for bootstrap, make_spack, make_subspack

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -4,30 +4,44 @@
 
 usage() {
   cat <<EOF
-usage: bootstrap [--with_padding] [--help] [dest_dir] [spack_infrastructure_version] [spack_version] [spack_repo]
+usage: bootstrap [options] [dest_dir] 
+  options:
+        --help                              Print this message
+        --with_padding                      Set padding in spack config
+        --spack_infrastructure_release ver  fetch the labeled version of spack_infrastructure
+        --spack_infrastructure_repo url     ...from this git reposity
+        --spack_release ver                 fetch the labeled version of spack_infrastructure
+        --spack_repo url                    ...from this git repository
+   dest_dir defaults to current directory
 EOF
 }
 # note, other scripts pull these values for defaults
 default_spack_infrastructure_version=master
 default_spack_version=v0.19.fermi
 default_spack_repo=https://github.com/FNALssi/spack.git
+default_spack_infrastructure_repo=https://github.com/FNALssi/spack-infrastructure.git
 
 parse_args() {
     with_padding=""
-    eval set : $(getopt --longoptions with_padding,help -- x "$@")
+    eval set : $(getopt --longoptions with_padding,help,spack_infrastructure_release:,spack_release:,spack_repo:,spack_infrastructure_repo: -- x "$@")
     shift
+    spack_repo=$default_spack_repo
+    spack_infrastructure_repo=$default_spack_infrastructure_repo
+    ver=$default_spack_infrastructure_version
+    spack_version=$default_spack_version
     while [ "${1:0:2}" = "--" ]
     do
         case "x$1" in
-        x--with_padding) with_padding="--with_padding"; shift; continue;;
+        x--with_padding)                 with_padding="--with_padding"; shift;;
+        x--spack_release)                spack_version=$2; shift; shift ;;
+        x--spack_repo)                   spack_repo=$2; shift; shift ;;
+        x--spack_infrastructure_release) ver=$2; shift; shift ;;
+        x--spack_infrastructure_repo)    spack_infrastructure_repo=$2; shift; shift ;;
         x--help) usage; exit;;
         x--) shift; break;;
         esac
     done
     dest=${1:-$PWD}
-    ver=${2:-$default_spack_infrastructure_version}
-    spack_version=${3:-$default_spack_version}
-    spack_repo=${4:-$default_spack_repo}
 }
 
 detail_log() {
@@ -92,7 +106,7 @@ main() {
     cd $dest
 
     message "Cloning FNALssi spack-infrastructure repository"
-    git clone -b $ver https://github.com/FNALssi/spack-infrastructure.git spack-infrastructure/$ver/NULL/
+    git clone -b $ver $spack_infrastructure_repo spack-infrastructure/$ver/NULL/
 
     PATH=$dest/spack-infrastructure/$ver/NULL/bin:$PATH
 

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -4,11 +4,13 @@
 
 usage() {
   cat <<EOF
-usage: bootstrap [--with_padding] [--help] [dest_dir] [spack_infrastructure_version] [spack_version]
+usage: bootstrap [--with_padding] [--help] [dest_dir] [spack_infrastructure_version] [spack_version] [spack_repo]
 EOF
 }
+# note, other scripts pull these values for defaults
 default_spack_infrastructure_version=master
 default_spack_version=v0.19.fermi
+default_spack_repo=https://github.com/FNALssi/spack.git
 
 parse_args() {
     with_padding=""
@@ -25,7 +27,8 @@ parse_args() {
     echo "after while: args $*"
     dest=${1:-$PWD}
     ver=${2:-$default_spack_infrastructure_version}
-    spackver=${3:-$default_spack_version}
+    spack_version=${3:-$default_spack_version}
+    spack_repo=${4:-$default_spack_repo}
 }
 
 detail_log() {
@@ -95,14 +98,14 @@ main() {
     PATH=$dest/spack-infrastructure/$ver/NULL/bin:$PATH
 
     message "Setting up with make_spack"
-    make_spack --spack_release $spackver $with_padding --minimal -u $dest
+    make_spack --spack_release $spack_version --spack_repo $spack_repo $with_padding --minimal -u $dest
 
     message "Finding compilers"
     source $dest/setup-env.sh
 
     spack compiler find --scope=site
 
-    cd $dest/spack-infrastructure/$ver/NULL && bin/declare_simple spack-infrastructure $ver
+    spack install spack-infrastructure@$ver
 
     check_bootstrap
 }

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -24,7 +24,6 @@ parse_args() {
         x--) shift; break;;
         esac
     done
-    echo "after while: args $*"
     dest=${1:-$PWD}
     ver=${2:-$default_spack_infrastructure_version}
     spack_version=${3:-$default_spack_version}
@@ -105,7 +104,7 @@ main() {
 
     spack compiler find --scope=site
 
-    spack install spack-infrastructure@$ver
+    cd $dest/spack-infrastructure/$ver/NULL && bin/declare_simple spack-infrastructure $ver
 
     check_bootstrap
 }

--- a/bin/make_spack
+++ b/bin/make_spack
@@ -179,8 +179,7 @@ get_from_bootstrap() {
 }
 
 parse_args() {
-    spack_repo=https://github.com/FNALssi/spack.git
-
+    spack_repo=$(get_from_bootstrap default_spack_repo)
     spack_release=$(get_from_bootstrap default_spack_version)
     use_buildcache=true
     minimal=false
@@ -188,7 +187,7 @@ parse_args() {
     padding=false
     layout=unified
 
-    eval set : $(getopt --longoptions with_padding,upgrade,spack_release:,minimal,no_buildcache --options mptu -- : "$@")
+    eval set : $(getopt --longoptions with_padding,upgrade,spack_release:,minimal,no_buildcache,spack_repo: --options mptu -- : "$@")
     shift
     while echo x$1 | grep x- > /dev/null
     do
@@ -198,6 +197,7 @@ parse_args() {
         x--spack_release)       spack_release=$2; shift; shift ;;
         x--minimal)             minimal=true; shift ;;
         x--no_buildcache)       use_buildcache=false; shift;;
+        x--spack_repo)          spack_repo=$2; shift; shift;;
         x-u)                    layout=unified; shift;;
         x-t)                    layout=traditional; shift;;
         x-p)                    layout=plain; shift;;

--- a/bin/make_spack
+++ b/bin/make_spack
@@ -164,6 +164,7 @@ usage(){
         echo "  --upgrade"
         echo "  --no-buildcache"
         echo "  --spack_release ver"
+        echo "  --spack_repo url"
         echo "  --minimal"
         echo "  make a spack instance with given layout"
         echo ""
@@ -195,9 +196,9 @@ parse_args() {
         x--with_padding)        padding=true; shift ;;
         x--upgrade)             upgrading=true; shift;;
         x--spack_release)       spack_release=$2; shift; shift ;;
+        x--spack_repo)          spack_repo=$2; shift; shift;;
         x--minimal)             minimal=true; shift ;;
         x--no_buildcache)       use_buildcache=false; shift;;
-        x--spack_repo)          spack_repo=$2; shift; shift;;
         x-u)                    layout=unified; shift;;
         x-t)                    layout=traditional; shift;;
         x-p)                    layout=plain; shift;;

--- a/bin/make_subspack
+++ b/bin/make_subspack
@@ -3,21 +3,22 @@
 # make a sub-spack repository
 # ...but make it unified layout...
 
-spack_repo=https://github.com/FNALssi/spack.git
 
 get_from_bootstrap() {
     grep "^$1=" $spackbindir/bootstrap | sed -e 's/.*=//'
 }
 
+
 usage() {
-    echo "usage: make_subspack [--spack_release ver] [-t|-u] /path/to/existing/spack /path/to/new/area"
+    echo "usage: make_subspack [--spack_release ver] [--spack_repo url] [-t|-u] /path/to/existing/spack /path/to/new/area"
 }
 
 parse_args() {
+    spack_repo=$(get_from_bootstrap default_spack_repo)
     spack_release=$(get_from_bootstrap  default_spack_version)
     padding=false
 
-    eval set : $(getopt --longoptions with_padding,spack_release: --options tu -- "$@")
+    eval set : $(getopt --longoptions with_padding,spack_release:,spack_repo --options tu -- "$@")
     shift
 
     while echo x$1 | grep x- > /dev/null
@@ -25,6 +26,7 @@ parse_args() {
         case "x$1" in
         x--with_padding)  padding=true; shift ;;
         x--spack_release) spack_release=$2; shift; shift;;
+        x--spack_repo)    spack_repo=$2; shift; shift;;
         x-t) unified=false; shift ;;
         x-u) unified=true; shift ;;
         x--) shift; break;;


### PR DESCRIPTION
Also updated bootstrap to take -- options for repositories, versions, etc.
```
usage: bootstrap [options] [dest_dir] 
  options:
        --help                              Print this message
        --with_padding                      Set padding in spack config
        --spack_infrastructure_release ver  fetch the labeled version of spack_infrastructure
        --spack_infrastructure_repo url     ...from this git reposity
        --spack_release ver                 fetch the labeled version of spack_infrastructure
        --spack_repo url                    ...from this git repository
   dest_dir defaults to current directory
```